### PR TITLE
add warn404 option and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Default: `undefined`
 
 Use an alternate registry
 
+#### warn404
+Type: `Boolean`
+Default: `false`
+
+Turn on if you want David not to abort if any errors are found. Error messages are then included in the report.
+
 ### Usage examples
 
 #### Update dependencies

--- a/tasks/david.js
+++ b/tasks/david.js
@@ -12,7 +12,8 @@ module.exports = function(grunt) {
     var options = this.options({
       update: false,
       unstable: false,
-      registry: null
+      registry: null,
+      warn404: false
     });
 
     var path = __dirname + '/../node_modules/.bin/';
@@ -31,6 +32,11 @@ module.exports = function(grunt) {
     // Use an alternate registry
     if(isString(options.registry)) {
       command += ' --registry ' + options.registry;
+    }
+
+    // Do not abort if errors are found (print errors instead)
+    if(options.warn404 === true) {
+      command += ' --warn404';
     }
 
     // Log david command


### PR DESCRIPTION
This pr adds possibility to include warn404 option in david task. With this feature, david task doesn't abort on errors, but prints out errors together with the outdated dependencies report.

Added because of the https://github.com/alanshaw/david/issues/48, where author states that warn404 option can be used to avoid the issue
